### PR TITLE
add angular-mocks to fix karma testing dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
     "url": "git://github.com/niemyjski/angular-filters.git"
   },
   "dependencies": {
-    "angular": ">=1.3.x"
+    "angular": ">=1.3.x",
+    "angular-mocks": "~1.3.7"
   },
   "ignore": [
     "node_modules"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'bower_components/angular/angular.js',
+      'bower_components/angular-mocks/angular-mocks.js',
       'src/angular-filters.js',
       'src/**/*.js'
     ],

--- a/karma.underscore.conf.js
+++ b/karma.underscore.conf.js
@@ -10,6 +10,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
         'bower_components/angular/angular.js',
+        'bower_components/angular-mocks/angular-mocks.js',
         'src/angular-filters.js',
         'src/**/*.js'
     ],


### PR DESCRIPTION
I wasn't able to run the karma tests when I forked the repo.  Maybe I'm doing something wrong, but this seemed to fix the grunt test task.  I thought you might want to incorporate the fix.

Cheers,
Josh
